### PR TITLE
Add TypedMessage for serialized json

### DIFF
--- a/models.go
+++ b/models.go
@@ -1,5 +1,12 @@
 package main
 
+import "encoding/json"
+
+type TypedMessage struct{
+	Type string
+	Data json.RawMessage
+}
+
 type AuthMessage struct {
 	UserID          string `json:"userID"`
 	SubscriptionKey string `json:"subscriptionKey"`

--- a/relay.go
+++ b/relay.go
@@ -186,7 +186,7 @@ func (rp *RelayProtocol) handleMessage(m []byte, userID string) error {
 		return err
 	}
 
-	message, err := unmarshalMessage(incomingMessage.Data)
+	message, err := unmarshalMessage(incomingMessage)
 	if err != nil {
 		return err
 	}
@@ -208,16 +208,22 @@ func (rp *RelayProtocol) handleMessage(m []byte, userID string) error {
 	return nil
 }
 
-func unmarshalMessage(m []byte) (interface{}, error) {
-	formatted := strings.Replace(string(m) , "\n", "", -1)
-	var encryptedMessage EncryptedMessage
-	if err := json.Unmarshal([]byte(formatted), &encryptedMessage); err == nil {
-		return encryptedMessage, nil
+func unmarshalMessage(message TypedMessage) (interface{}, error) {
+	formatted := strings.Replace(string(message.Data) , "\n", "", -1)
+
+	switch message.Type {
+	case "EncryptedMessage":
+		var encryptedMessage EncryptedMessage
+		if err := json.Unmarshal([]byte(formatted), &encryptedMessage); err == nil {
+			return encryptedMessage, nil
+		}
+	case "AckMessage":
+		var ack AckMessage
+		if err := json.Unmarshal([]byte(formatted), &ack); err == nil {
+			return ack, nil
+		}
 	}
-	var ack AckMessage
-	if err := json.Unmarshal([]byte(formatted), &ack); err == nil {
-		return ack, nil
-	}
+	
 	return nil, errors.New("unknown message type")
 }
 

--- a/relay.go
+++ b/relay.go
@@ -208,7 +208,7 @@ func (rp *RelayProtocol) handleMessage(m []byte, userID string) error {
 	return nil
 }
 
-func unmarshalMessage(message TypedMessage) (interface{}, error) {
+func unmarshalMessage(message *TypedMessage) (interface{}, error) {
 	formatted := strings.Replace(string(message.Data) , "\n", "", -1)
 
 	switch message.Type {
@@ -223,7 +223,7 @@ func unmarshalMessage(message TypedMessage) (interface{}, error) {
 			return ack, nil
 		}
 	}
-	
+
 	return nil, errors.New("unknown message type")
 }
 


### PR DESCRIPTION
So this would add an abstraction layer above the two message types so that we can clearly delineate the separates types. We're not using protobufs here so this is probably a cleaner way to do it with straight JSON.

So instead of: 
{ "messageID": "<ID>" } 

we would have:
{ "Type": "AckMessage", "Data": "<{ "messageID": "<ID>" } >" }

and we could unpack it better.