### PR TITLE
Added an example Auth setup for the browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ openbazaar-go*
 
 # macOS
 .DS_Store
+
+# JS Dependency directories
+**/node_modules/

--- a/examples/browserAuth/README.md
+++ b/examples/browserAuth/README.md
@@ -1,0 +1,18 @@
+# Webrelay Auth in the Browser
+
+This example will show you how to auth to your webrelay server from your client-side browser. After authing to the webrelay you will be able to forward OpenBazaar messages.
+
+## Setup
+
+This setup assumes you are running the OpenBazaar Webrelay on localhost + port 8080. If you need to update your host edit the "host" constant on auth.js
+
+```sh
+> npm install
+> npm start
+```
+
+After installing the dependencies you can run the auth example by opening up index.html in your local browser. 
+
+## Future Updates
+
+This example project will be expanded in the future to include browser messaging, order handling, and more. The goal is to eventually develop a full browser node for OB.

--- a/examples/browserAuth/auth.js
+++ b/examples/browserAuth/auth.js
@@ -1,0 +1,62 @@
+const multihash = require('multihashes'),
+    long = require("long"),
+    peerID = "QmaSAmPPynrWfz1R8XvRm1GX6ghzPze6XSZCov6fWWUzSg",
+    userID = Math.random().toString(36).substring(7),
+    host = "ws://localhost:8080";
+
+
+const connectSocket = (() => {
+    const socket = new WebSocket(host);
+
+    async function sha256(buffer) {
+        // hash the message
+        const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+        return Buffer.from(hashBuffer)
+    }
+
+    socket.addEventListener('open', (event) => {
+
+        // Convert the PeerID string to a Multihash object
+        const peerIDMultihash = multihash.fromB58String(peerID),
+
+            // Decode the Multihash to extract the digest
+            decoded = multihash.decode(peerIDMultihash),
+            digest = decoded.digest,
+
+            // Grab the first 8 bytes of the digest byte array
+            prefix = digest.slice(0, 8),
+
+
+            // Convert Uint8Array to Uint64 Big-Endian
+            prefix64 = new long.fromBytesBE(prefix, true),
+
+            // Bit shift prefix 48 bits to the right
+            shiftedPrefix64 = prefix64.shiftRightUnsigned(48),
+
+            // Convert prefix to buffer
+            shiftedPrefix64Buffer = Buffer.from(shiftedPrefix64.toBytesBE());
+
+        // Hash the buffer
+        sha256(shiftedPrefix64Buffer).then((sha) => {
+            // Re-encode as a multihash to get your SubscriptionKey
+            const subscriptionKey = multihash.toB58String(multihash.encode(sha, "sha2-256")),
+                authMessage = { userID: userID, subscriptionKey: subscriptionKey };
+            // Send message to the server
+            console.log(authMessage)
+            socket.send(JSON.stringify(authMessage))
+        })
+
+    });
+
+    // Listen for messages from the server
+    socket.addEventListener('message', (event) => {
+        document.getElementById("serverMessage").innerHTML = `Message from server: ${event.data}`
+    });
+
+    socket.addEventListener('error', (event) => {
+        // Reconnect to socket on d/c
+        setTimeout(() => { connectSocket() }, 500)
+    });
+})
+
+connectSocket();

--- a/examples/browserAuth/index.html
+++ b/examples/browserAuth/index.html
@@ -1,0 +1,14 @@
+<html>
+
+<head>
+    <script src="bundle.js"></script>
+</head>
+
+<body>
+	<h1> Webrelay Browser Auth Example </h1>
+    <div id="serverMessage">
+    	Connecting...
+    </div>
+</body>
+
+</html>

--- a/examples/browserAuth/package.json
+++ b/examples/browserAuth/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "webrelay",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "browserify auth.js -o bundle.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "long": "^4.0.0",
+    "multihashes": "^0.4.14",
+    "browserify": "^16.2.0"
+  }
+}


### PR DESCRIPTION
Added auth project that shows how to securely auth to a webrelay from the browser. I thought it would be helpful for users looking to develop their own browser client.

This example project will be expanded in the future to include browser messaging, order handling, and more. The goal is to eventually develop a full browser node for OB.